### PR TITLE
Ruff workaround

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: mixed-line-ending
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.5
+    hooks:
+      - id: ruff
+        args: [--fix]
   - repo: local
     hooks:
       - id: pyre

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,15 @@ dependencies = [
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+# Same as Black.
+line-length = 120
+indent-width = 4
+
+# Assume Python 3.13
+target-version = "py313"
+
+[tool.ruff.lint]
+# 1. Enable flake8-bugbear (`B`) rules, in addition to the defaults.
+select = ["UP"]

--- a/pyre_mre/main.py
+++ b/pyre_mre/main.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Generator
 
+type Nothing = None | None
 
-def infinite_stream(start: int) -> Generator[int]:
+def infinite_stream(start: int) -> Generator[int, Nothing, Nothing]:
     """From https://docs.python.org/3/library/typing.html#annotating-generators-and-coroutines."""
     while True:
         yield start

--- a/pyre_mre/main.py
+++ b/pyre_mre/main.py
@@ -1,8 +1,9 @@
 """Minimal reproducible example of possible Pyre-check bug."""
+
 from collections.abc import Generator
 
 
-def infinite_stream(start: int) -> Generator[int, None, None]:
+def infinite_stream(start: int) -> Generator[int]:
     """From https://docs.python.org/3/library/typing.html#annotating-generators-and-coroutines."""
     while True:
         yield start

--- a/pyre_mre/main.py
+++ b/pyre_mre/main.py
@@ -2,7 +2,7 @@
 from collections.abc import Generator
 
 
-def infinite_stream(start: int) -> Generator[int]:
+def infinite_stream(start: int) -> Generator[int, None, None]:
     """From https://docs.python.org/3/library/typing.html#annotating-generators-and-coroutines."""
     while True:
         yield start


### PR DESCRIPTION
The type of workaround needed to satisfy both Ruff-format and Pyre-check.