### PR TITLE
Import from typing library

### DIFF
--- a/pyre_mre/main.py
+++ b/pyre_mre/main.py
@@ -1,5 +1,5 @@
 """Minimal reproducible example of possible Pyre-check bug."""
-from collections.abc import Generator
+from typing import Generator
 
 
 def infinite_stream(start: int) -> Generator[int]:


### PR DESCRIPTION
Importing `Generator` from typing causes a different error.